### PR TITLE
Change publishing query to use server timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
-.dist/
-.giant_mixins.egg-info/
+.vscode
+.pytest_cache
+*__pycache__
+*.egg-info
+poetry.lock
+dist

--- a/mixins/models.py
+++ b/mixins/models.py
@@ -2,6 +2,7 @@ from urllib.parse import parse_qs, urlparse
 
 from django.core.validators import URLValidator
 from django.db import models
+from django.db.models.functions import Now
 from django.utils import timezone
 
 from .fields import AutoDateTimeField
@@ -37,7 +38,7 @@ class PublishingQuerySetMixin(models.QuerySet):
         Return the published queryset
         """
 
-        return self.filter(is_published=True, publish_at__lte=timezone.now())
+        return self.filter(is_published=True, publish_at__lte=Now())
 
 
 class PublishingMixin(models.Model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-mixins"
-version = "0.1.1.3"
+version = "0.1.1.4"
 description = "A mixins app that provides some standard mixins for Giant projects"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
Should fix the issue present in Re:act where published articles must have a publish at before the last live deploy