### PR TITLE
Change publishing queryset to allow for admin to view all objects

### DIFF
--- a/mixins/models.py
+++ b/mixins/models.py
@@ -33,10 +33,12 @@ class PublishingQuerySetMixin(models.QuerySet):
     whose date is less than the current date
     """
 
-    def published(self):
+    def published(self, user=None):
         """
-        Return the published queryset
+        Return the published queryset, or all if user is admin
         """
+        if user and user.is_staff:
+            return self.all()
 
         return self.filter(is_published=True, publish_at__lte=Now())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-mixins"
-version = "0.1.1.4"
+version = "0.1.1.5"
 description = "A mixins app that provides some standard mixins for Giant projects"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
allows the admin users to view all objects which will allow them the content without needing to publish first