### PR TITLE
Add URL mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ This will include the standard mixins such as TimestampMixin, PublishingMixin an
 
 ## Installation
 
-To install with the package manager simply run
+To install the standard app with no extras simply run
 
     $ poetry add giant-mixins
 
-You should then add `"mixins"` to the `INSTALLED_APPS` in your settings file.
+However if your project has django-cms installed then you can make use of the full range of mixins in this app. For this, install the package with the extra dependencies,
 
+    $ poetry add giant-mixins --extras "cms"
+
+You should then add `"mixins"` to the `INSTALLED_APPS` in your settings file.

--- a/mixins/models.py
+++ b/mixins/models.py
@@ -1,11 +1,10 @@
 from urllib.parse import parse_qs, urlparse
 
 from django.core.validators import URLValidator
+from django.conf import settings
 from django.db import models
 from django.db.models.functions import Now
 from django.utils import timezone
-
-from cms.models.fields import PageField
 
 from .fields import AutoDateTimeField
 
@@ -91,10 +90,12 @@ class YoutubeURLMixin(models.Model):
 class URLMixin(models.Model):
     """
     Helper mixin to add internal and external url's to a model
+    Requires django-cms to be installed
     """
+    from cms.models.fields import PageField
 
-    internal_link = PageField(related_name="+", blank=True, null=True)
     external_url = models.URLField(blank=True, help_text="Overrides the internal link if set")
+    internal_link = PageField(related_name="+", blank=True, null=True)
 
     class Meta:
         abstract = True

--- a/mixins/models.py
+++ b/mixins/models.py
@@ -5,6 +5,8 @@ from django.db import models
 from django.db.models.functions import Now
 from django.utils import timezone
 
+from cms.models.fields import PageField
+
 from .fields import AutoDateTimeField
 
 __all__ = [
@@ -84,3 +86,24 @@ class YoutubeURLMixin(models.Model):
         video_id = parse_qs(urlparse(youtube_url).query["v"][0])
 
         return f"https://www.youtube.com/embed/{video_id}?rel=0&autoplay=1"
+
+
+class URLMixin(models.Model):
+    """
+    Helper mixin to add internal and external url's to a model
+    """
+
+    internal_link = PageField(related_name="+", blank=True, null=True)
+    external_url = models.URLField(blank=True, help_text="Overrides the internal link if set")
+
+    class Meta:
+        abstract = True
+
+    @property
+    def get_absolute_url(self):
+        """
+        Returns the URL's in order of importance
+        """
+        if self.external_url:
+            return self.external_url
+        return self.internal_link.get_absolute_url

--- a/mixins/models.py
+++ b/mixins/models.py
@@ -92,6 +92,8 @@ class URLMixin(models.Model):
     Helper mixin to add internal and external url's to a model
     Requires django-cms to be installed
     """
+    # We import here to avoid an error when loading the file. This will only error if cms is not installed and
+    # the URLMixin attempts to be loaded
     from cms.models.fields import PageField
 
     external_url = models.URLField(blank=True, help_text="Overrides the internal link if set")

--- a/mixins/tests/test_giant_mixins.py
+++ b/mixins/tests/test_giant_mixins.py
@@ -1,5 +1,0 @@
-from mixins import __version__
-
-
-def test_version():
-    assert __version__ == "0.1.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,18 +23,22 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+django-cms = {version = "^3.7.3", optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
 black = "^19.10b0"
 django = "2.2"
-django-cms = "^3.7.2"
 
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+[tool.poetry.extras]
+cms = ["django-cms"]
 
 [[tool.poetry.source]]
 name = "TestPyPi"
 url = "https://test.pypi.org/simple/"
 secondary = true
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-mixins"
-version = "0.1.1.5"
+version = "0.1.2"
 description = "A mixins app that provides some standard mixins for Giant projects"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"
@@ -28,6 +28,7 @@ python = "^3.6"
 pytest = "^5.2"
 black = "^19.10b0"
 django = "2.2"
+django-cms = "^3.7.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Adds a URL mixin. Also removed the relatively useless test. The new mixin REQUIRES cms to be installed alongside the package. As it is an optional dependency it can be installed by specifying the `extras` flag when running `poetry install`. I think this is a good starting point and would ideally like to include the use case where a project doesn't include django-cms. The easiest solution to his would be to write a separate mixin which uses both fields as URLfields and removes the need to cms to be installed. Seeing as this is a very rare case (at the moment), I will leave that implementation until the best solution has been found 