### PR TITLE
Update youtube_url helptext on the video mixin

### DIFF
--- a/mixins/models.py
+++ b/mixins/models.py
@@ -69,9 +69,10 @@ class VideoURLMixin(models.Model):
         blank=True,
         null=True,
         help_text="""
-            Enter the full URL of the youtube video page. 
-            To start the video at a specific time add '&t=xx' to the end of the url (using seconds). 
-            You can also add extra paramaters using an ampersand, for example '&t=75&autoplay=1'.
+            Enter the full URL of the youtube video page.
+            To start the video at a specific time add '?start=xx' to the end
+            of the url (using seconds). You can also add extra paramaters
+            using an ampersand, for example '?start=25&autoplay=1'.
         """,
         validators=[
             URLValidator(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-mixins"
-version = "0.3.3"
+version = "0.3.4"
 description = "A mixins app that provides some standard mixins for Giant projects"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"


### PR DESCRIPTION
We've had a few requests around autoplaying and starting videos at a specific time when using a modal. I've recently added this to Macular so the FE package we use allows the extra parameters: https://github.com/giantmade/macular/blob/develop/frontend/static/src/js/image_video-modal.js#L19

I'm adding that JS snippet to the new vanilla project, so it'll be good to get the help text up-to-date on the mixin.