### PR TITLE
Allow any version of Django CMS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giant-mixins"
-version = "0.3.3"
+version = "0.3.4"
 description = "A mixins app that provides some standard mixins for Giant projects"
 authors = ["Will-Hoey <will.hoey@giantmade.com>"]
 license = "MIT"
@@ -23,7 +23,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-django-cms = {version = "~3", optional = true}
+django-cms = {version = "*", optional = true}
 django-filer = "~2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
These mixins could be used on a variety of different CMS versions, including 3 and 4. The optional dependency specified here is used when using the "cms" extras flag. Projects using CMS should pin their version outside of this project if they need a specific version.